### PR TITLE
fix(MeasurementLayerBase): map height and width correctly

### DIFF
--- a/src/lib/components/core/MeasurementLayerBase.js
+++ b/src/lib/components/core/MeasurementLayerBase.js
@@ -41,7 +41,7 @@ export default class MeasurementLayerBase extends PureComponent {
           key={measurement.id}
           line={measurement}
           parentWidth={this.props.widthInPx}
-          parentHeight={this.props.widthInPx}
+          parentHeight={this.props.heightInPx}
           measureLine={this.props.measureLine}
           onChange={this.onChange}
           onCommit={this.props.onCommit}
@@ -54,7 +54,7 @@ export default class MeasurementLayerBase extends PureComponent {
           key={measurement.id}
           circle={measurement}
           parentWidth={this.props.widthInPx}
-          parentHeight={this.props.widthInPx}
+          parentHeight={this.props.heightInPx}
           measureCircle={this.props.measureCircle}
           onChange={this.onChange}
           onCommit={this.props.onCommit}
@@ -67,7 +67,7 @@ export default class MeasurementLayerBase extends PureComponent {
           key={measurement.id}
           text={measurement}
           parentWidth={this.props.widthInPx}
-          parentHeight={this.props.widthInPx}
+          parentHeight={this.props.heightInPx}
           onChange={this.onChange}
           onCommit={this.props.onCommit}
           onDeleteButtonClick={this.delete}


### PR DESCRIPTION
I was trying to accurately fit a rectangular image when I found out that the MeasurementLayer component only rendered square areas, regardless of the height dimensions. 

After digging into the library I found out that only width from the parent was being mapped to both height and width, which causes this behavior.

This is a mistake I also did when constructing my custom component, so it was one of the first things I checked XD.

Great library, we are currently using it to build the UI of [FiberDiameter](https://github.com/fcossio/FiberDiameter)